### PR TITLE
Added getPokemonIdByNameIgnoreCase

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function(name) {
    */
   function getPokemonIdByName(name) {
 
-    var ii = 0;
+    var ii = 1;
     var length = Object.keys(PKMN_TABLE).length;
 
     for (; ii < length; ++ii) {
@@ -83,6 +83,19 @@ module.exports = function(name) {
     return (0);
 
   };
+
+
+  function getPokemonIdByNameIgnoreCase(name) {
+
+    var ii = 1;
+    var length = Object.keys(PKMN_TABLE).length;
+ 
+     for (; ii < length; ++ii) {
+       if (PKMN_TABLE[ii].toLowerCase() === name.toLowerCase()) return (ii);
+     };
+ 
+     return (0);
+  }
 
   /**
    * @return {Number}
@@ -110,7 +123,8 @@ module.exports = function(name) {
     getPokemonNameById: getPokemonNameById,
     getPokemonIdByName: getPokemonIdByName,
     getRandomPokemonName: getRandomPokemonName,
-    getRandomPokemonId: getRandomPokemonId
+    getRandomPokemonId: getRandomPokemonId,
+    getPokemonIdByNameIgnoreCase: getPokemonIdByNameIgnoreCase
   };
 
 };

--- a/test/index.js
+++ b/test/index.js
@@ -48,3 +48,10 @@ expect(typeof randId === "number" && randId >= 1 && randId <= 721);
 // Random pkmn name
 var randName = pkmn.getRandomPokemonName();
 expect(typeof randName === "string");
+
+// Ignore Casing
+expect(pkmn2.getPokemonIdByName("Bulbasaur") === 1);
+expect(pkmn2.getPokemonIdByName("bulbasaur") === 0);
+expect(pkmn2.getPokemonIdByNameIgnoreCase("Bulbasaur") === 1);
+expect(pkmn2.getPokemonIdByNameIgnoreCase("bulbasaur") === 1);
+


### PR DESCRIPTION
Allows for one to find a pokemon without having the casing correct ( for example Ho-Oh ).